### PR TITLE
[RFC] Replace HTTP/JSON with Downloads/JSON3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,11 @@ authors = ["Rory Linehan <rorylinehan@protonmail.com>"]
 version = "0.4.1"
 
 [deps]
-HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 
 [compat]
-HTTP = "0.9, 1"
-JSON = "0.21"
+JSON3 = "1.12"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
Here are some changes that I personally think might improve this package. The main part is the replacement of JSON with JSON3, which avoid building nested `Dict` when parsing the response body (and also result in a better display for `OpenAIResponse` in the REPL for free). The replacement of HTTP with Downloads stdlib is minor, depending on whether less dependency is preferable or not.