### PR TITLE
Add chat streaming

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.8.0"
 
 [deps]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 
 [compat]

--- a/src/OpenAI.jl
+++ b/src/OpenAI.jl
@@ -80,9 +80,6 @@ function request_body_live(url; method, input, headers, streamcallback, kwargs..
         end
     end
 
-    println(resp)
-    println(body)
-
     return resp, body
 end
 

--- a/src/OpenAI.jl
+++ b/src/OpenAI.jl
@@ -88,7 +88,7 @@ function status_error(resp, log=nothing)
     error("request status $(resp.message)$logs")
 end
 
-function _request(api::AbstractString, provider::AbstractOpenAIProvider, api_key::AbstractString=provider.api_key; method, streamcallback, kwargs...)
+function _request(api::AbstractString, provider::AbstractOpenAIProvider, api_key::AbstractString=provider.api_key; method, streamcallback=nothing, kwargs...)
     # add stream: True to the API call if a stream callback function is passed
     if !isnothing(streamcallback)
         kwargs = (kwargs..., stream=true)

--- a/src/OpenAI.jl
+++ b/src/OpenAI.jl
@@ -2,6 +2,7 @@ module OpenAI
 
 using Downloads
 using JSON3
+using HTTP
 
 
 abstract type AbstractOpenAIProvider end

--- a/test/completion.jl
+++ b/test/completion.jl
@@ -22,6 +22,25 @@
   if !=(r.status, 200)
     @test false
   end
+
+  # streaming chat
+  r = create_chat(
+    ENV["OPENAI_API_KEY"], 
+    "gpt-3.5-turbo",
+    [Dict("role" => "user", "content"=> "What continent is New York in? Two word answer.")],
+    streamcallback = let
+      count = 0
+      
+      function f(s::String)
+        count = count + 1
+        println("Chunk $count")
+      end
+    end)
+    
+  println(map(r->r["choices"][1]["delta"], r.response))
+  if !=(r.status, 200)
+    @test false
+  end
 end
 
 @testset "create edit" begin


### PR DESCRIPTION
Adds the streaming chat request mentioned in #19! The new code implements a client for the [server-sent events](https://platform.openai.com/docs/api-reference/chat/create#chat/create-stream) mentioned in the OpenAI docs. If a callback function (that accepts a string) is passed to `create_chat(...)` via the `streamcallback`, a streaming request will be sent and the OpenAI server will send back a bunch of chunks that can be reassembled into the ChatGPT message response. **Note:** the response looks different in streaming mode, so code that calls `create_chat` with streaming will need to deal with that.

Open questions:
- Should the callbacks be expected to accept a string, or JSON? Could go either way. Most of the time I bet the callback function will do JSON parsing, so maybe a good idea to save code and do the JSON parsing before calling the callback
- Is there a cleaner way to write this? There are a few instances of `if isnothing(streamcallback)` that feel like they could be replaced with some type system stuff. I couldn't find a quick way to do that. The code here works well though.
- Should tests be added? I haven't included any but is probably a good idea.

## References 
- https://juliaweb.github.io/HTTP.jl/stable/client/
- https://platform.openai.com/docs/api-reference/chat/create#chat/create-stream