### PR TITLE
fixed issue with HTTP.request kwargs propagation

### DIFF
--- a/test/completion.jl
+++ b/test/completion.jl
@@ -23,11 +23,23 @@
     @test false
   end
 
+  # with http kwargs (with default values)
+  r = create_chat(
+    ENV["OPENAI_API_KEY"],
+    "gpt-3.5-turbo",
+    [Dict("role" => "user", "content" => "Summarize HTTP.jl package in one sentence.")],
+    http_kwargs=(connect_timeout=10, readtimeout=0)
+  )
+  println(r.response["choices"][begin]["message"]["content"])
+  if !=(r.status, 200)
+    @test false
+  end
+
   # streaming chat
   r = create_chat(
     ENV["OPENAI_API_KEY"],
     "gpt-3.5-turbo",
-    [Dict("role" => "user", "content" => "What continent is New York in? Two word answer.")],
+    [Dict("role" => "user", "content" => "What continent is New York in? Two word answer.")],    
     streamcallback=let
       count = 0
 


### PR DESCRIPTION
The issue: inside the `_request` function, all the `kwargs` are collected and prepared for the OpenAI API call using the `request_body` function. The subsequent call to `request_body` (and `request_body_live`) is not passing any keyword argument (resulting in no `kwargs` passed to `HTTP.request`). So, there is no way for the user to alter the values of `connect_timeout` and `readtimeout` from HTTP.jl.

In the current PR, I added the possibility of propagating the HTTP. request specific keyword arguments.

Example:

```
r = create_chat(
    ENV["OPENAI_API_KEY"],
    "gpt-3.5-turbo",
    [Dict("role" => "user", "content" => "Summarize HTTP.jl package in one sentence.")],
    http_kwargs=(connect_timeout=10, readtimeout=0)
  )
```

I acknowledge that another approach might have been setting some global `TIMEOUT` value (and still is). However, there are other keyword arguments supported by HTTP.jl package that the users might want to use: this implementation enables the user to pass an arbitrarily named tuple to http_kwargs and have more granular control over the HTTP.jl behavior.